### PR TITLE
Don't skip second packet of RTP sequence.

### DIFF
--- a/src/function_send.c
+++ b/src/function_send.c
@@ -459,30 +459,30 @@ void* sendbuilt (void *parameters)
 			}
 			/* changing RTP values: seq number++, timestamp for 10ms */
 			if ( (p->inc & (1<<6)) && (p->l4_proto_in_use == 17)) {
-				packet[p->udpstart+10] = (li+1)/256;
-				packet[p->udpstart+11] = (li+1)%256;
-				packet[p->udpstart+12] = ((li+1)*80)/16777216;
-				packet[p->udpstart+13] = ((li+1)*80)/65536;
-				packet[p->udpstart+14] = ((li+1)*80)/256;
-				packet[p->udpstart+15] = (signed int)(((li+1)*80)%256);
+				packet[p->udpstart+10] = li/256;
+				packet[p->udpstart+11] = li%256;
+				packet[p->udpstart+12] = (li*80)/16777216;
+				packet[p->udpstart+13] = (li*80)/65536;
+				packet[p->udpstart+14] = (li*80)/256;
+				packet[p->udpstart+15] = (signed int)((li*80)%256);
 			}
 			/* changing RTP values: seq number++, timestamp for 20ms */
 			if ( (p->inc & (1<<7)) && (p->l4_proto_in_use == 17)) {
-				packet[p->udpstart+10] = (li+1)/256;
-				packet[p->udpstart+11] = (li+1)%256;
-				packet[p->udpstart+12] = ((li+1)*160)/16777216;
-				packet[p->udpstart+13] = ((li+1)*160)/65536;
-				packet[p->udpstart+14] = ((li+1)*160)/256;
-				packet[p->udpstart+15] = (signed int)(((li+1)*160)%256);
+				packet[p->udpstart+10] = li/256;
+				packet[p->udpstart+11] = li%256;
+				packet[p->udpstart+12] = (li*160)/16777216;
+				packet[p->udpstart+13] = (li*160)/65536;
+				packet[p->udpstart+14] = (li*160)/256;
+				packet[p->udpstart+15] = (signed int)((li*160)%256);
 			}
 			/* changing RTP values: seq number++, timestamp for 30ms */
 			if ( (p->inc & (1<<8)) && (p->l4_proto_in_use == 17)) {
-				packet[p->udpstart+10] = (li+1)/256;
-				packet[p->udpstart+11] = (li+1)%256;
-				packet[p->udpstart+12] = ((li+1)*240)/16777216;
-				packet[p->udpstart+13] = ((li+1)*240)/65536;
-				packet[p->udpstart+14] = ((li+1)*240)/256;
-				packet[p->udpstart+15] = (signed int)(((li+1)*240)%256);
+				packet[p->udpstart+10] = li/256;
+				packet[p->udpstart+11] = li%256;
+				packet[p->udpstart+12] = (li*240)/16777216;
+				packet[p->udpstart+13] = (li*240)/65536;
+				packet[p->udpstart+14] = (li*240)/256;
+				packet[p->udpstart+15] = (signed int)((li*240)%256);
 			}
 			/* changing byte x value */
 			if (p->inc & (1<<9)) {


### PR DESCRIPTION
When using RTP stream generation through automatic sequence
number incrementing the loop code causes the second RTP packet
to be skipped, due to an off-by-one error.
Remove adding 1 to next field value calculations.

Signed-off-by: Jaap Keuter <jaap.keuter@xs4all.nl>