### PR TITLE
add configure (compile time) option to increase maximum MTU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packETH
 src/*.o
 src/.deps/*
 stamp-h1
+!configure.ac

--- a/cli-new/cli_send.c
+++ b/cli-new/cli_send.c
@@ -958,8 +958,8 @@ four(char *iftext, long delay, long pkt2send, char* filename, char *sizetmp, int
 			cleanupRules(num_rules);			
 			return 1;
 		}
-		if (stopsize > 9000) {
-			printf("\nstopsize must be <9000\n\n");
+		if (stopsize > MAX_MTU) {
+			printf("\nstopsize must be <%d\n\n", MAX_MTU);
 			close(fd);
 			cleanupRules(num_rules);			
 			return 1;

--- a/cli/cli_send.c
+++ b/cli/cli_send.c
@@ -39,6 +39,10 @@
 #include <netdb.h>
 
 #define PCAP_MAGIC   0xa1b2c3d4
+#ifndef MAX_MTU
+    #define MAX_MTU 9000
+	#define MAX_MTU_STR "9000"
+#endif
 
 /* "libpcap" file header (minus magic number). */
 struct pcap_hdr {
@@ -69,6 +73,7 @@ void usage(void);
 
 int main(int argc, char *argv[])
 {
+printf("%d\n", MAX_MTU);
         char iftext[20];
         char sizetmp[20];
         char filename[100];
@@ -408,8 +413,8 @@ int two(char *iftext, long delay, long pkt2send, char* filename, char *sizetmp, 
 			printf("\nstartsize must be >60\n\n");
 			return 1;
 		}
-		if (stopsize > 9000) {
-			printf("\nstopsize must be <9000\n\n");
+		if (stopsize > MAX_MTU) {
+			printf("\nstopsize must be <" MAX_MTU_STR "\n\n");
 			return 1;
 		}
 		size = startsize;

--- a/cli_dev/cli_send.c
+++ b/cli_dev/cli_send.c
@@ -426,8 +426,8 @@ int two(char *iftext, long delay, long pkt2send, char* filename, char *sizetmp, 
 			printf("\nstartsize must be >60\n\n");
 			return 1;
 		}
-		if (stopsize > 9000) {
-			printf("\nstopsize must be <9000\n\n");
+		if (stopsize > MAX_MTU) {
+			printf("\nstopsize must be <" MAX_MTU_STR "\n\n");
 			return 1;
 		}
 		size = startsize;

--- a/configure.ac
+++ b/configure.ac
@@ -30,4 +30,14 @@ AC_FUNC_STRTOD
 AC_CHECK_FUNCS([bzero ftime gettimeofday isascii memset socket strchr strtol strtoul strtoull])
 
 AC_CONFIG_FILES([Makefile])
+
+# Option to define a larger (or smaller) maximum MTU
+AC_ARG_WITH([mtu], [AS_HELP_STRING([--with-mtu], [change the maximum MTU, default: 9000])])
+AS_IF([test "x$with_mtu" != "x"],
+	[AC_DEFINE_UNQUOTED([MAX_MTU], [${with_mtu}], ["..."])],
+	[AC_DEFINE_UNQUOTED([MAX_MTU], [9000], ["..."])])
+AS_IF([test "x$with_mtu" != "x"],
+	[AC_DEFINE_UNQUOTED([MAX_MTU_STR], ["${with_mtu}"], ["..."])],
+	[AC_DEFINE_UNQUOTED([MAX_MTU_STR], ["9000"], ["..."])])
+
 AC_OUTPUT

--- a/src/function.c
+++ b/src/function.c
@@ -46,6 +46,7 @@
 #include "function.h"
 #include "function_send.h"
 #include "headers.h"
+#include "config.h"
 
 /* some global variables:
  * packet [] - the packet contents 
@@ -859,16 +860,16 @@ int send_packet(GtkButton *button, gpointer user_data)
 			params1.ramp_step = strtoll(en229_t, (char **)NULL, 10);
 			params1.ramp_interval = strtoll(en230_t, (char **)NULL, 10);
 
-			if ( (params1.ramp_start > 9000) || (params1.ramp_start < 60) ) {
-				error("Error: Size ramp start length (60 - 9000 bytes)");
+			if ( (params1.ramp_start > MAX_MTU) || (params1.ramp_start < 60) ) {
+				error("Error: Size ramp start length (60 - " MAX_MTU_STR "bytes)");
 				return -1;
 			}
-			if ( (params1.ramp_stop > 9000) || (params1.ramp_stop < 60) ) {
-				error("Error: Size ramp stop length (60 - 9000 bytes)");
+			if ( (params1.ramp_stop > MAX_MTU) || (params1.ramp_stop < 60) ) {
+				error("Error: Size ramp stop length (60 - " MAX_MTU_STR " bytes)");
 				return -1;
 			}
-			if ( (params1.ramp_step > 9000) || (params1.ramp_step < 1) ) {
-				error("Error: Size ramp step length (1 - 9000 bytes)");
+			if ( (params1.ramp_step > MAX_MTU) || (params1.ramp_step < 1) ) {
+				error("Error: Size ramp step length (1 - " MAX_MTU_STR " bytes)");
 				return -1;
 			}
 			if ( (params1.ramp_interval > 999999) || (params1.ramp_interval < 1) ) {


### PR DESCRIPTION
Hi,

thanks for your work on packETH so far! I found out, that I have to increase the MTU beyond 9000 (my Mellanox card actually supports 9978) to reach 99GBit/s. I thought it would be best, to introduce a constant, that can be changed at compile time. Hope, you like it!

For the GUI, it's:
`./configure --with-mtu=9978`

For cli it's:
`make CPPFLAGS='-DMAX_MTU=9399 -DMAX_MTU_STR=\"9399\"'`

Regards
Kay

PS: I am not very familiar with autoconf. Do you think it would be possible to add cli to it's build process, as another target?