### PR TITLE
Fix GCC-10 / CFLAGS=-fno-common

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -65,7 +65,6 @@ extern int number;
 extern int stop_flag;
 extern long desired_bw;
 gint row_number;/* this is because i cant get the selected row number*/
-gchar iftext[20];
 gchar address_filename[100] = "addresslist";
 static GtkWidget *entry_field;
 static GtkWidget *entry_field_ip;

--- a/src/function.c
+++ b/src/function.c
@@ -66,7 +66,7 @@ int ipv4_start = 0;
 int ipv6_start = 0;
 int eth_start = 0;
 gboolean stop_flag = 0;
-extern char iftext[20];
+char iftext[20];
 static unsigned long crc32_table[256];
 int crc32_table_init = 0;
 int ip_proto_used = 0; // 0 - none, 4 - ipv4, 6- IPv6, 806 - ARP

--- a/src/function.h
+++ b/src/function.h
@@ -22,6 +22,8 @@
 
 #include <gtk/gtk.h>
 
+extern char iftext[20];
+
 signed int char2x(char *p);
 char c4(int value);
 guint32 get_checksum32(int start, int stop);	

--- a/src/function_send.c
+++ b/src/function_send.c
@@ -55,7 +55,6 @@ extern long li_last_packets_sent;
 extern long li_packets_sent_lastsec;
 extern long sentstream[10];
 extern long sendtime;
-char iftext[20];
 
 struct params  {
 	long long del;


### PR DESCRIPTION
GCC 10 will enable -fno-common by default[0], which causes the linker to
fail like this [1], even for older GCC versions for which it is
explicitly enabled:
```
ld: src/function_send.o:(.bss+0x0): multiple definition of `iftext';
src/callbacks.o:(.bss+0x0): first defined here
```
Fix[2] this by declaring iftext as extern in the header and by defining it
just once.

[0] https://gcc.gnu.org/gcc-10/porting_to.html#common
[1] https://bugs.gentoo.org/708048
[2] Note that src/function.h uses CRLF line endings.