### PR TITLE
Provide the correct length in snprintf

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1465,7 +1465,7 @@ on_Gen_button_clicked                    (GtkButton       *button,
 	else {
 		/* copy data to tmp field */
 		for (i=0, j=0, m=1; j < number; m++, j++) {
-			snprintf(&tmp[i], 31000, "%02x", packet[j]);
+			snprintf(&tmp[i], 31000-i, "%02x", packet[j]);
 			i++; i++;
 			/* we allow only 16 bytes in each row - looks nicer */
 			if ((m % 16) == 0 && (m > 1)) {


### PR DESCRIPTION
The buffer `tmp` is 31000 long, so when we write at offset `i`, the remaining length is `31000 - i`.

The snprintf implementation in Ubuntu 24.04 actually seems to check this value, before this change, the program would crash with the message

```
*** buffer overflow detected ***: terminated
```

There may be more occurences like this, I just found and fixed this single one.

This probably also fixes #45 